### PR TITLE
Ensures that missing keys from the config file are set in the internal config

### DIFF
--- a/lib/pronto/fasterer.rb
+++ b/lib/pronto/fasterer.rb
@@ -57,7 +57,7 @@ module Pronto
     def config
       @config ||=
         if File.exist?(CONFIG_FILE_NAME)
-          YAML.load_file(CONFIG_FILE_NAME)
+          nil_config_file.merge(YAML.load_file(CONFIG_FILE_NAME))
         else
           nil_config_file
         end


### PR DESCRIPTION
If you would have a `.fasterer.yml` config with only the `speedups` key pronto would fail because it expects the `exclude_path` key to be there too. By merging the actual file in the default `nil_config_file` we ensure that all keys are set internally and default to an empty value for unset keys.