### PR TITLE
Fix a bug with config instance variable

### DIFF
--- a/lib/pronto/fasterer.rb
+++ b/lib/pronto/fasterer.rb
@@ -34,7 +34,7 @@ module Pronto
     end
 
     def config
-      @config ||= ::Fasterer::Config.new
+      @fasterer_config ||= ::Fasterer::Config.new
     end
   end
 end


### PR DESCRIPTION
Hello!

When I run `pronto` with `pronto-fasterer`, I get the following error:
```
$ pronto run -c origin/develop
/Users/mgrachev/project/vendor/bundle/bundler/gems/pronto-fasterer-3d98abea6d2b/lib/pronto/fasterer.rb:9:in `block in run': undefined method `ignored_files' for #<Pronto::Config:0x007fd6069c26e0> (NoMethodError)
	from /Users/mgrachev/project/vendor/bundle/bundler/gems/pronto-fasterer-3d98abea6d2b/lib/pronto/fasterer.rb:8:in `reject'
	from /Users/mgrachev/project/vendor/bundle/bundler/gems/pronto-fasterer-3d98abea6d2b/lib/pronto/fasterer.rb:8:in `run'
	from /Users/mgrachev/project/vendor/bundle/bundler/gems/pronto-9bc0bfa8a6fa/lib/pronto/runners.rb:20:in `block in run'
	from /Users/mgrachev/project/vendor/bundle/bundler/gems/pronto-9bc0bfa8a6fa/lib/pronto/runners.rb:13:in `each'
	from /Users/mgrachev/project/vendor/bundle/bundler/gems/pronto-9bc0bfa8a6fa/lib/pronto/runners.rb:13:in `run'
	from /Users/mgrachev/project/vendor/bundle/bundler/gems/pronto-9bc0bfa8a6fa/lib/pronto.rb:60:in `run'
	from /Users/mgrachev/project/vendor/bundle/bundler/gems/pronto-9bc0bfa8a6fa/lib/pronto/cli.rb:61:in `block in run'
	from /Users/mgrachev/project/vendor/bundle/bundler/gems/pronto-9bc0bfa8a6fa/lib/pronto/cli.rb:60:in `chdir'
	from /Users/mgrachev/project/vendor/bundle/bundler/gems/pronto-9bc0bfa8a6fa/lib/pronto/cli.rb:60:in `run'
	from /Users/mgrachev/project/vendor/bundle/gems/thor-0.19.4/lib/thor/command.rb:27:in `run'
	from /Users/mgrachev/project/vendor/bundle/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
	from /Users/mgrachev/project/vendor/bundle/gems/thor-0.19.4/lib/thor.rb:369:in `dispatch'
	from /Users/mgrachev/project/vendor/bundle/gems/thor-0.19.4/lib/thor/base.rb:444:in `start'
	from /Users/mgrachev/project/vendor/bundle/bundler/gems/pronto-9bc0bfa8a6fa/bin/pronto:6:in `<top (required)>'
	from /Users/mgrachev/project/vendor/bundle/bin/pronto:17:in `load'
	from /Users/mgrachev/project/vendor/bundle/bin/pronto:17:in `<main>'
```

The problem in the instance variable is `@config`, because It is initially declared in the method [Pronto::Runner#initialize](https://github.com/mmozuras/pronto/blob/master/lib/pronto/runner.rb#L8).